### PR TITLE
Add initial project configuration files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,74 @@
+target/
+lib_managed/
+src_managed/
+project/boot/
+project/plugins/project/
+generated-docs/
+docs-gen-tmp/
+
+.history
+.cache
+.lib/
+### Scala template
+*.class
+*.log
+### Eclipse template
+
+.metadata
+bin/
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.settings/
+.loadpath
+.recommenders
+
+# External tool builders
+.externalToolBuilders/
+
+# Locally stored "Eclipse launch configurations"
+*.launch
+
+# sbt
+.bsp/
+.bloop/
+.metals/
+.vscode/
+/dotty-docs/
+
+# sbteclipse plugin
+.target
+
+# Scala IDE specific (Scala & Java development for Eclipse)
+.cache-main
+.scala_dependencies
+.worksheet
+### macOS template
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Thumbnails
+._*
+
+# Package Files #
+*.jar
+*.war
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+### JetBrains template
+.idea/
+*.iml
+.idea_modules/
+
+# IntelliJ
+out/

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,67 @@
+version = 3.7.4
+runner.dialect = scala213
+
+//align.preset=more
+align.arrowEnumeratorGenerator=true
+align.tokens = [
+  {
+    code = "%"
+    owners = [{
+      regex = "Term.ApplyInfix"
+    }]
+  }, {
+    code = "%%"
+    owners = [{
+      regex = "Term.ApplyInfix"
+    }]
+//  }, {
+//    code = ":="
+//    owners = [{
+//      regex = "Term.ApplyInfix",
+//    }]
+  }, {
+    code = "->"
+    owners = [{
+      regex = "Term.ApplyInfix",
+    }]
+  }, {
+    code = "="
+    owners = [{
+      regex = "(Enumerator.Val|Defn.(Va(l|r)|GivenAlias|Def|Type))"
+    }]
+  }, {
+    code = "<-"
+    owners = [{
+      regex = "Enumerator.Generator"
+    }]
+  },
+]
+
+maxColumn=120
+assumeStandardLibraryStripMargin=false
+
+continuationIndent.callSite=2
+continuationIndent.defnSite=2
+
+align.stripMargin=true
+align.multiline=true
+align.openParenCallSite=false
+align.openParenDefnSite=false
+
+includeCurlyBraceInSelectChains=true
+includeNoParensInSelectChains=true
+
+spaces.beforeContextBoundColon=Never
+
+//newlines.beforeMultiline=unfold
+newlines.beforeMultilineDef=keep
+newlines.alwaysBeforeElseAfterCurlyIf=false
+newlines.beforeCurlyLambdaParams=multilineWithCaseOnly
+newlines.afterCurlyLambdaParams=never
+newlines.implicitParamListModifierPrefer = before
+
+trailingCommas=multiple
+
+docstrings.style = SpaceAsterisk
+docstrings.oneline = keep
+docstrings.wrap = false

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,79 @@
+ThisBuild / scalaVersion := props.ProjectScalaVersion
+ThisBuild / organization := "io.kevinlee"
+ThisBuild / organizationName := "Kevin's Code"
+
+ThisBuild / developers := List(
+  Developer(
+    props.GitHubUsername,
+    "Kevin Lee",
+    "kevin.code@kevinlee.io",
+    url(s"https://github.com/${props.GitHubUsername}"),
+  )
+)
+ThisBuild / homepage := url(s"https://github.com/${props.GitHubUsername}/${props.RepoName}").some
+ThisBuild / scmInfo :=
+  ScmInfo(
+    browseUrl = url(s"https://github.com/${props.GitHubUsername}/${props.RepoName}"),
+    connection = s"scm:git:git@github.com:${props.GitHubUsername}/${props.RepoName}.git",
+  ).some
+
+ThisBuild / licenses := props.licenses
+
+ThisBuild / resolvers += "sonatype-snapshots" at s"https://${props.SonatypeCredentialHost}/content/repositories/snapshots"
+
+lazy val logbackScalaInterop = (project in file("."))
+  .enablePlugins(
+    DevOopsJavaPlugin,
+    DevOopsGitHubReleasePlugin,
+  )
+  .settings(
+    name := props.ProjectName,
+    javacOptions := Seq(
+      "-source",
+      javaVersion.value,
+      "-encoding",
+      "UTF-8",
+    ),
+    Compile / compile / javacOptions ++= Seq(
+      "-target",
+      javaVersion.value,
+      "-Xlint:unchecked",
+      "-g",
+      "-deprecation",
+    ),
+    Compile / test / javacOptions := (Compile / compile / javacOptions).value,
+    libraryDependencies ++= Seq(
+      libs.logbackClassic
+    ),
+  )
+  .settings(mavenCentralPublishSettings)
+
+lazy val props =
+  new {
+
+    val GitHubUsername = "kevin-lee"
+    val RepoName       = "logback-scala-interop"
+
+    val ProjectName = RepoName
+
+    final val ProjectScalaVersion = "2.13.11"
+
+    lazy val licenses = List(License.MIT)
+
+    val SonatypeCredentialHost = "s01.oss.sonatype.org"
+    val SonatypeRepository     = s"https://$SonatypeCredentialHost/service/local"
+
+    final val LogbackVersion = "1.4.7"
+  }
+
+lazy val libs = new {
+  lazy val logbackClassic: ModuleID = "ch.qos.logback" % "logback-classic" % props.LogbackVersion
+
+}
+
+lazy val mavenCentralPublishSettings: SettingsDefinition = List(
+  /* Publish to Maven Central { */
+  sonatypeCredentialHost := props.SonatypeCredentialHost,
+  sonatypeRepository := props.SonatypeRepository,
+  /* } Publish to Maven Central */
+)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.9.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,10 @@
+logLevel := sbt.Level.Warn
+
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.10")
+
+val sbtDevOopsVersion = "2.24.0"
+addSbtPlugin("io.kevinlee" % "sbt-devoops-java"      % sbtDevOopsVersion)
+addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-extra" % sbtDevOopsVersion)
+addSbtPlugin("io.kevinlee" % "sbt-devoops-github"    % sbtDevOopsVersion)
+
+addSbtPlugin("io.kevinlee" % "sbt-devoops-starter"    % sbtDevOopsVersion)


### PR DESCRIPTION
Add initial project configuration files
This commit introduces the primary configuration files needed for the project setup. We added "build.sbt" for setting up the sbt build tool for the Scala project, ".gitignore" to ignore unnecessary files while committing to git repository, and lastly, "project/plugins.sbt" for adding necessary sbt plugins, and "project/build.properties" specifying the sbt version. This essential config setup lays the foundation for further development.