### PR TITLE
Add `JLoggerFMdcAdapter` for supporting Scala interoperability

### DIFF
--- a/src/main/java/logback_scala_interop/JLoggerFMdcAdapter.java
+++ b/src/main/java/logback_scala_interop/JLoggerFMdcAdapter.java
@@ -1,0 +1,20 @@
+package logback_scala_interop;
+
+import ch.qos.logback.classic.util.LogbackMDCAdapter;
+
+import java.util.Map;
+
+/**
+ * @author Kevin Lee
+ * @since 2023-02-18
+ */
+public abstract class JLoggerFMdcAdapter extends LogbackMDCAdapter {
+
+  public abstract void setContextMap0(final Map<String, String> contextMap);
+
+  @Override
+  public void setContextMap(final Map contextMap) {
+    setContextMap0(contextMap);
+  }
+
+}


### PR DESCRIPTION
Add `JLoggerFMdcAdapter` for supporting Scala interoperability
New class, `JLoggerFMdcAdapter`, was added to support proper integration between Java and Scala for logging purposes. It extends the `LogbackMDCAdapter`, allows setting the context map, promoting better log management within mixed Java/Scala codebases.