### PR TITLE
logback-scala-interop v0.1.0

### DIFF
--- a/changelogs/0.1.0.md
+++ b/changelogs/0.1.0.md
@@ -1,0 +1,4 @@
+## [0.1.0](https://github.com/kevin-lee/logback-scala-interop/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am1) - 2023-07-02
+
+## Done
+* Add `JLoggerFMdcAdapter` for supporting Scala interoperability (#6)


### PR DESCRIPTION
# logback-scala-interop v0.1.0
## [0.1.0](https://github.com/kevin-lee/logback-scala-interop/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am1) - 2023-07-02

## Done
* Add `JLoggerFMdcAdapter` for supporting Scala interoperability (#6)
