### PR TITLE
logback-scala-interop v0.2.0

### DIFF
--- a/changelogs/0.2.0.md
+++ b/changelogs/0.2.0.md
@@ -1,0 +1,4 @@
+## [0.2.0](https://github.com/kevin-lee/logback-scala-interop/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am2) - 2023-09-13
+
+## Done
+* Bump logback to `1.4.8` (#10)


### PR DESCRIPTION
# logback-scala-interop v0.2.0
## [0.2.0](https://github.com/kevin-lee/logback-scala-interop/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am2) - 2023-09-13

## Done
* Bump logback to `1.4.8` (#10)
