### PR TITLE
logback-scala-interop v0.3.0

### DIFF
--- a/changelogs/0.3.0.md
+++ b/changelogs/0.3.0.md
@@ -1,0 +1,4 @@
+## [0.3.0](https://github.com/kevin-lee/logback-scala-interop/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am3) - 2023-09-14
+
+## Done
+* Bump logback to `1.4.9` (#13)


### PR DESCRIPTION
# logback-scala-interop v0.3.0
## [0.3.0](https://github.com/kevin-lee/logback-scala-interop/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am3) - 2023-09-14

## Done
* Bump logback to `1.4.9` (#13)
