### PR TITLE
logback-scala-interop v0.4.0

### DIFF
--- a/changelogs/0.4.0.md
+++ b/changelogs/0.4.0.md
@@ -1,0 +1,4 @@
+## [0.4.0](https://github.com/kevin-lee/logback-scala-interop/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am4) - 2023-09-14
+
+## Done
+* Bump logback to `1.4.10` (#16)


### PR DESCRIPTION
# logback-scala-interop v0.4.0
## [0.4.0](https://github.com/kevin-lee/logback-scala-interop/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am4) - 2023-09-14

## Done
* Bump logback to `1.4.10` (#16)
