### PR TITLE
logback-scala-interop v0.5.0

### DIFF
--- a/changelogs/0.5.0.md
+++ b/changelogs/0.5.0.md
@@ -1,0 +1,4 @@
+## [0.5.0](https://github.com/kevin-lee/logback-scala-interop/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am5) - 2023-09-15
+
+## Done
+* Bump logback to `1.4.11` (#19)


### PR DESCRIPTION
# logback-scala-interop v0.5.0
## [0.5.0](https://github.com/kevin-lee/logback-scala-interop/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am5) - 2023-09-15

## Done
* Bump logback to `1.4.11` (#19)
