### PR TITLE
logback-scala-interop v0.7.0

### DIFF
--- a/changelogs/0.7.0.md
+++ b/changelogs/0.7.0.md
@@ -1,0 +1,4 @@
+## [0.7.0](https://github.com/kevin-lee/logback-scala-interop/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am7) - 2023-12-05
+
+## Done
+* Bump logback to `1.4.13` (#26)


### PR DESCRIPTION
# logback-scala-interop v0.7.0
## [0.7.0](https://github.com/kevin-lee/logback-scala-interop/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am7) - 2023-12-05

## Done
* Bump logback to `1.4.13` (#26)
