### PR TITLE
logback-scala-interop v0.8.0

### DIFF
--- a/changelogs/0.8.0.md
+++ b/changelogs/0.8.0.md
@@ -1,0 +1,4 @@
+## [0.8.0](https://github.com/kevin-lee/logback-scala-interop/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am8) - 2023-12-31
+
+## Done
+* Bump logback to `1.4.14` (#31)


### PR DESCRIPTION
# logback-scala-interop v0.8.0
## [0.8.0](https://github.com/kevin-lee/logback-scala-interop/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am8) - 2023-12-31

## Done
* Bump logback to `1.4.14` (#31)
