### PR TITLE
logback-scala-interop v1.0.0

### DIFF
--- a/changelogs/1.0.0.md
+++ b/changelogs/1.0.0.md
@@ -1,0 +1,4 @@
+## [1.0.0](https://github.com/kevin-lee/logback-scala-interop/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am9) - 2024-03-03
+
+## Done
+* Bump logback to `1.5.0` (#37)


### PR DESCRIPTION
# logback-scala-interop v1.0.0
## [1.0.0](https://github.com/kevin-lee/logback-scala-interop/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am9) - 2024-03-03

## Done
* Bump logback to `1.5.0` (#37)
