### PR TITLE
logback-scala-interop v1.3.0

### DIFF
--- a/changelogs/1.3.0.md
+++ b/changelogs/1.3.0.md
@@ -1,0 +1,4 @@
+## [1.3.0](https://github.com/kevin-lee/logback-scala-interop/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am12) - 2024-03-12
+
+## Done
+* Bump logback to `1.5.3` (#46)


### PR DESCRIPTION
# logback-scala-interop v1.3.0
## [1.3.0](https://github.com/kevin-lee/logback-scala-interop/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am12) - 2024-03-12

## Done
* Bump logback to `1.5.3` (#46)
