### PR TITLE
logback-scala-interop v1.4.0

### DIFF
--- a/changelogs/1.4.0.md
+++ b/changelogs/1.4.0.md
@@ -1,0 +1,4 @@
+## [1.4.0](https://github.com/kevin-lee/logback-scala-interop/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am13) - 2024-11-17
+
+## Done
+* Bump logback to `1.5.4` (#51)


### PR DESCRIPTION
# logback-scala-interop v1.4.0
## [1.4.0](https://github.com/kevin-lee/logback-scala-interop/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am13) - 2024-11-17

## Done
* Bump logback to `1.5.4` (#51)
