### PR TITLE
logback-scala-interop v1.6.0

### DIFF
--- a/changelogs/1.6.0.md
+++ b/changelogs/1.6.0.md
@@ -1,0 +1,4 @@
+## [1.6.0](https://github.com/kevin-lee/logback-scala-interop/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am15) - 2024-11-17
+
+## Done
+* Bump logback to `1.5.6` (#54)


### PR DESCRIPTION
# logback-scala-interop v1.6.0
## [1.6.0](https://github.com/kevin-lee/logback-scala-interop/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am15) - 2024-11-17

## Done
* Bump logback to `1.5.6` (#54)
