### PR TITLE
logback-scala-interop v1.7.0

### DIFF
--- a/changelogs/1.7.0.md
+++ b/changelogs/1.7.0.md
@@ -1,0 +1,4 @@
+## [1.7.0](https://github.com/kevin-lee/logback-scala-interop/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am16) - 2024-11-18
+
+## Done
+* Bump logback to `1.5.7` (#56)


### PR DESCRIPTION
# logback-scala-interop v1.7.0
## [1.7.0](https://github.com/kevin-lee/logback-scala-interop/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am16) - 2024-11-18

## Done
* Bump logback to `1.5.7` (#56)
