### PR TITLE
logback-scala-interop v1.8.0

### DIFF
--- a/changelogs/1.8.0.md
+++ b/changelogs/1.8.0.md
@@ -1,0 +1,4 @@
+## [1.8.0](https://github.com/kevin-lee/logback-scala-interop/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am17) - 2024-11-19
+
+## Done
+* Bump logback to `1.5.8` (#57)


### PR DESCRIPTION
# logback-scala-interop v1.8.0
## [1.8.0](https://github.com/kevin-lee/logback-scala-interop/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am17) - 2024-11-19

## Done
* Bump logback to `1.5.8` (#57)
