### PR TITLE
logback-scala-interop v1.9.0

### DIFF
--- a/changelogs/1.9.0.md
+++ b/changelogs/1.9.0.md
@@ -1,0 +1,4 @@
+## [1.9.0](https://github.com/kevin-lee/logback-scala-interop/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am18) - 2024-11-20
+
+## Done
+* Bump logback to `1.5.9` (#58)


### PR DESCRIPTION
# logback-scala-interop v1.9.0
## [1.9.0](https://github.com/kevin-lee/logback-scala-interop/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am18) - 2024-11-20

## Done
* Bump logback to `1.5.9` (#58)
