### PR TITLE
logback-scala-interop v1.10.0

### DIFF
--- a/changelogs/1.10.0.md
+++ b/changelogs/1.10.0.md
@@ -1,0 +1,4 @@
+## [1.10.0](https://github.com/kevin-lee/logback-scala-interop/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am19) - 2024-11-21
+
+## Done
+* Bump logback to `1.5.10` (#59)


### PR DESCRIPTION
# logback-scala-interop v1.10.0
## [1.10.0](https://github.com/kevin-lee/logback-scala-interop/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am19) - 2024-11-21

## Done
* Bump logback to `1.5.10` (#59)
