### PR TITLE
logback-scala-interop v1.11.0

### DIFF
--- a/changelogs/1.11.0.md
+++ b/changelogs/1.11.0.md
@@ -1,0 +1,4 @@
+## [1.11.0](https://github.com/kevin-lee/logback-scala-interop/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am20) - 2024-11-23
+
+## Done
+* Bump logback to `1.5.11` (#60)


### PR DESCRIPTION
# logback-scala-interop v1.11.0
## [1.11.0](https://github.com/kevin-lee/logback-scala-interop/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am20) - 2024-11-23

## Done
* Bump logback to `1.5.11` (#60)
