### PR TITLE
logback-scala-interop v1.12.0

### DIFF
--- a/changelogs/1.12.0.md
+++ b/changelogs/1.12.0.md
@@ -1,0 +1,4 @@
+## [1.12.0](https://github.com/kevin-lee/logback-scala-interop/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am21) - 2024-11-24
+
+## Done
+* Bump logback to `1.5.12` (#61)


### PR DESCRIPTION
# logback-scala-interop v1.12.0
## [1.12.0](https://github.com/kevin-lee/logback-scala-interop/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am21) - 2024-11-24

## Done
* Bump logback to `1.5.12` (#61)
