### PR TITLE
logback-scala-interop v1.13.0

### DIFF
--- a/changelogs/1.13.0.md
+++ b/changelogs/1.13.0.md
@@ -1,0 +1,7 @@
+## [1.13.0](https://github.com/kevin-lee/logback-scala-interop/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am22) - 2025-03-05
+
+## Done
+* Bump logback to `1.5.13` (#84)
+
+## Fixed
+* GitHub Actions: `sbt` is missing in the build (#82)


### PR DESCRIPTION
# logback-scala-interop v1.13.0
## [1.13.0](https://github.com/kevin-lee/logback-scala-interop/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am22) - 2025-03-05

## Done
* Bump logback to `1.5.13` (#84)

## Fixed
* GitHub Actions: `sbt` is missing in the build (#82)
