### PR TITLE
logback-scala-interop v1.14.0

### DIFF
--- a/changelogs/1.14.0.md
+++ b/changelogs/1.14.0.md
@@ -1,0 +1,4 @@
+## [1.14.0](https://github.com/kevin-lee/logback-scala-interop/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am23) - 2025-03-05
+
+## Done
+* Bump logback to `1.5.14` (#85)


### PR DESCRIPTION
# logback-scala-interop v1.14.0
## [1.14.0](https://github.com/kevin-lee/logback-scala-interop/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am23) - 2025-03-05

## Done
* Bump logback to `1.5.14` (#85)
