### PR TITLE
logback-scala-interop v1.15.0

### DIFF
--- a/changelogs/1.15.0.md
+++ b/changelogs/1.15.0.md
@@ -1,0 +1,4 @@
+## [1.15.0](https://github.com/kevin-lee/logback-scala-interop/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am24) - 2025-03-05
+
+## Done
+* Bump logback to `1.5.15` (#86)


### PR DESCRIPTION
# logback-scala-interop v1.15.0
## [1.15.0](https://github.com/kevin-lee/logback-scala-interop/issues?q=is%3Aissue+is%3Aclosed+milestone%3Am24) - 2025-03-05

## Done
* Bump logback to `1.5.15` (#86)
