### PR TITLE
logback-scala-interop v1.16.0

### DIFF
--- a/changelogs/1.16.0.md
+++ b/changelogs/1.16.0.md
@@ -1,0 +1,4 @@
+## [1.16.0](https://github.com/kevin-lee/logback-scala-interop/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Am25) - 2025-03-05
+
+## Done
+* Bump logback to `1.5.16` (#87)


### PR DESCRIPTION
# logback-scala-interop v1.16.0
## [1.16.0](https://github.com/kevin-lee/logback-scala-interop/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Am25) - 2025-03-05

## Done
* Bump logback to `1.5.16` (#87)
